### PR TITLE
fix to drop_materialization in drop.ipynb

### DIFF
--- a/analysis/drop.ipynb
+++ b/analysis/drop.ipynb
@@ -56,6 +56,7 @@
     "        return\n",
     "    materialization_id = conn.nickname_id(\"materializations\", materialization)\n",
     "    sessions = conn.db_query(f\"SELECT nickname FROM sessions WHERE materialization = {materialization_id}\")\n",
+    "    sessions = [i[0] for i in sessions]\n",
     "    for session in sessions:\n",
     "        drop_session(conn, session)"
    ]


### PR DESCRIPTION
Added additional list comp so an error isn't thrown when it tries to pass a tuple to db_query string